### PR TITLE
0.1 SparQL ORM basic implementation

### DIFF
--- a/sparql_orm/Cargo.toml
+++ b/sparql_orm/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sparql_orm"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/sparql_orm/src/graph_specifier.rs
+++ b/sparql_orm/src/graph_specifier.rs
@@ -1,11 +1,10 @@
 //!
 //! Basic types for handling graph specifiers in sparql
 //!
-    
-pub type GraphIdent = String; 
+
+pub type GraphIdent = String;
 
 /// A trait that marks any type that can represent a graph specifier
 pub trait GraphSpecifier {
     fn gen_specifier(&self) -> GraphIdent;
 }
-

--- a/sparql_orm/src/graph_specifier.rs
+++ b/sparql_orm/src/graph_specifier.rs
@@ -1,0 +1,11 @@
+//!
+//! Basic types for handling graph specifiers in sparql
+//!
+    
+pub type GraphIdent = String; 
+
+/// A trait that marks any type that can represent a graph specifier
+pub trait GraphSpecifier {
+    fn gen_specifier(&self) -> GraphIdent;
+}
+

--- a/sparql_orm/src/identifier.rs
+++ b/sparql_orm/src/identifier.rs
@@ -1,4 +1,3 @@
-
 //!
 //! Basic types to represent a single SPARQL Identifier
 //! i.e. `name`, or `foaf:author`,
@@ -15,4 +14,3 @@ impl Identifier for Ident {
         self.clone()
     }
 }
-

--- a/sparql_orm/src/identifier.rs
+++ b/sparql_orm/src/identifier.rs
@@ -1,7 +1,18 @@
 
 //!
 //! Basic types to represent a single SPARQL Identifier
+//! i.e. `name`, or `foaf:author`,
 //!
 
 pub type Ident = String;
+
+pub trait Identifier {
+    fn gen_identifier(&self) -> Ident;
+}
+
+impl Identifier for Ident {
+    fn gen_identifier(&self) -> Ident {
+        self.clone()
+    }
+}
 

--- a/sparql_orm/src/identifier.rs
+++ b/sparql_orm/src/identifier.rs
@@ -1,0 +1,7 @@
+
+//!
+//! Basic types to represent a single SPARQL Identifier
+//!
+
+pub type Ident = String;
+

--- a/sparql_orm/src/identifier.rs
+++ b/sparql_orm/src/identifier.rs
@@ -2,6 +2,7 @@
 //! Basic types to represent a single SPARQL Identifier
 //! i.e. `name`, or `foaf:author`,
 //!
+use crate::query_build::{QueryFragment, SparqlQuery};
 
 pub type Ident = String;
 
@@ -12,5 +13,15 @@ pub trait Identifier {
 impl Identifier for Ident {
     fn gen_identifier(&self) -> Ident {
         self.clone()
+    }
+}
+use crate::query_build::QueryBuilder;
+
+impl<T> QueryFragment for T
+where
+    T: Identifier,
+{
+    fn generate_fragment(&self, builder: &mut QueryBuilder) {
+        builder.write_element(&self.gen_identifier());
     }
 }

--- a/sparql_orm/src/insert_data_clause.rs
+++ b/sparql_orm/src/insert_data_clause.rs
@@ -1,0 +1,31 @@
+//!
+//! A module containing insert clause related functionality, traits
+//! and types
+
+use std::marker::PhantomData;
+use crate::identifier::*;
+use crate::triple_pattern::SPQLConstTriple;
+
+/// A marker trait for types that can be evaluated as part of 
+/// a InsertDataClause. Not that this explicitly will not 
+/// include variable binding triple patterns, 
+/// as those are not supported by INSERT DATA 
+///
+pub trait InsertableDataTripleSet {}
+
+/// A trait that marks any type that can represent a graph specifier
+pub trait GraphSpecifier {}
+
+pub struct EmptyTripleSet;
+
+pub struct InsertTripleSet<CT: SPQLConstTriple, RST: InsertableDataTripleSet> {
+    ct: PhantomData<CT>,
+    rst: PhantomData<RST>,
+}
+
+impl InsertableDataTripleSet for EmptyTripleSet {}
+
+pub struct InsertDataClause<G: GraphSpecifier, SEL: InsertableDataTripleSet> {
+    a: PhantomData<G>,
+    b: PhantomData<SEL>,
+}

--- a/sparql_orm/src/insert_data_clause.rs
+++ b/sparql_orm/src/insert_data_clause.rs
@@ -5,6 +5,7 @@
 use std::marker::PhantomData;
 use crate::identifier::*;
 use crate::triple_pattern::SPQLConstTriple;
+use crate::graph_specifier::GraphSpecifier;
 
 /// A marker trait for types that can be evaluated as part of 
 /// a InsertDataClause. Not that this explicitly will not 
@@ -13,8 +14,6 @@ use crate::triple_pattern::SPQLConstTriple;
 ///
 pub trait InsertableDataTripleSet {}
 
-/// A trait that marks any type that can represent a graph specifier
-pub trait GraphSpecifier {}
 
 pub struct EmptyTripleSet;
 

--- a/sparql_orm/src/insert_data_clause.rs
+++ b/sparql_orm/src/insert_data_clause.rs
@@ -2,19 +2,17 @@
 //! A module containing insert clause related functionality, traits
 //! and types
 
-use std::marker::PhantomData;
+use crate::graph_specifier::GraphSpecifier;
 use crate::identifier::*;
 use crate::triple_pattern::SPQLConstTriple;
-use crate::graph_specifier::GraphSpecifier;
+use std::marker::PhantomData;
 
-/// A marker trait for types that can be evaluated as part of 
-/// a InsertDataClause. Not that this explicitly will not 
-/// include variable binding triple patterns, 
-/// as those are not supported by INSERT DATA 
+/// A marker trait for types that can be evaluated as part of
+/// a InsertDataClause. Not that this explicitly will not
+/// include variable binding triple patterns,
+/// as those are not supported by INSERT DATA
 ///
 pub trait InsertableDataTripleSet {}
-
-
 pub struct EmptyTripleSet;
 
 pub struct InsertTripleSet<CT: SPQLConstTriple, RST: InsertableDataTripleSet> {

--- a/sparql_orm/src/lib.rs
+++ b/sparql_orm/src/lib.rs
@@ -3,8 +3,8 @@
 //! sparql based queries. It implements a subset
 //! of the w3c specification for both query and update calls
 
-pub mod sparql_var;
-pub mod triple_pattern;
+pub mod graph_specifier;
 pub mod identifier;
 pub mod insert_data_clause;
-pub mod graph_specifier;
+pub mod sparql_var;
+pub mod triple_pattern;

--- a/sparql_orm/src/lib.rs
+++ b/sparql_orm/src/lib.rs
@@ -6,6 +6,6 @@
 pub mod graph_specifier;
 pub mod identifier;
 pub mod insert_data_clause;
+pub mod query_build;
 pub mod sparql_var;
 pub mod triple_pattern;
-pub mod query_build;

--- a/sparql_orm/src/lib.rs
+++ b/sparql_orm/src/lib.rs
@@ -1,0 +1,8 @@
+//!
+//! This library is a diesel inspired flavor, of a possible ORM for
+//! sparql based queries. It implements a subset
+//! of the w3c specification for both query and update calls
+
+pub mod sparql_var;
+pub mod triple_pattern;
+pub mod identifier;

--- a/sparql_orm/src/lib.rs
+++ b/sparql_orm/src/lib.rs
@@ -6,3 +6,4 @@
 pub mod sparql_var;
 pub mod triple_pattern;
 pub mod identifier;
+pub mod insert_data_clause;

--- a/sparql_orm/src/lib.rs
+++ b/sparql_orm/src/lib.rs
@@ -8,3 +8,4 @@ pub mod identifier;
 pub mod insert_data_clause;
 pub mod sparql_var;
 pub mod triple_pattern;
+pub mod query_build;

--- a/sparql_orm/src/lib.rs
+++ b/sparql_orm/src/lib.rs
@@ -7,3 +7,4 @@ pub mod sparql_var;
 pub mod triple_pattern;
 pub mod identifier;
 pub mod insert_data_clause;
+pub mod graph_specifier;

--- a/sparql_orm/src/query_build.rs
+++ b/sparql_orm/src/query_build.rs
@@ -1,0 +1,66 @@
+//!
+//! Contains constructs that handle, manage, and implement 
+//! actual sparql query generation
+//!
+
+pub struct QueryBuilder {
+    curr_query: String,
+}
+
+impl QueryBuilder {
+    fn new() -> Self {
+        QueryBuilder { curr_query: String::new() }
+    }
+    fn write_element(&mut self, frag: &str) {
+        self.curr_query.push_str(&frag);
+    }
+
+    //TODO - we can probably do something smarter via references
+    fn get_result(&self) -> String {
+        self.curr_query.clone()
+    }
+}
+
+///
+/// The key trait that makes this all work - essentially all
+/// types corresponding to a sparql type should implement this type 
+/// it'll allow us to run a full query build and view the output, 
+/// as if this were an AST pass
+///
+pub trait QueryFragment {
+    //TODO: we need error handling, this should be fallible
+    fn generate_fragment(&self, builder: &mut QueryBuilder); 
+}
+
+///
+/// A trait to mark "complete" queries, as opposed to fragmented types
+pub trait SparqlQuery {
+    fn generate_query(&self, builder: &mut QueryBuilder);
+}
+impl<T> QueryFragment for T where T: SparqlQuery {
+
+    fn generate_fragment(&self, builder: &mut QueryBuilder) {
+        self.generate_query(builder);     
+    }
+}
+
+pub fn run_sparql_generation<T: SparqlQuery>(obj: T) -> String {
+    // I don't want to expose 
+    // a public interface to any function that allows 
+    // folks to generate a non-complete sparql query,
+    // however since TraitSparqlQuery is a subtype of QueryFragment, 
+    // we can just use this internally
+    test_gen_fragment(obj)
+}
+
+pub(crate) fn test_gen_fragment<T: QueryFragment>(query_fragment: T) -> String {
+    let mut query_builder = QueryBuilder::new();
+    query_fragment.generate_fragment(&mut query_builder);
+    query_builder.get_result()
+}
+
+
+#[cfg(test)]
+mod fragment_tests {
+    // TODO: add tests after we have types which implement QueryFragment
+}

--- a/sparql_orm/src/query_build.rs
+++ b/sparql_orm/src/query_build.rs
@@ -1,5 +1,5 @@
 //!
-//! Contains constructs that handle, manage, and implement 
+//! Contains constructs that handle, manage, and implement
 //! actual sparql query generation
 //!
 
@@ -9,9 +9,11 @@ pub struct QueryBuilder {
 
 impl QueryBuilder {
     fn new() -> Self {
-        QueryBuilder { curr_query: String::new() }
+        QueryBuilder {
+            curr_query: String::new(),
+        }
     }
-    fn write_element(&mut self, frag: &str) {
+    pub fn write_element(&mut self, frag: &str) {
         self.curr_query.push_str(&frag);
     }
 
@@ -23,42 +25,33 @@ impl QueryBuilder {
 
 ///
 /// The key trait that makes this all work - essentially all
-/// types corresponding to a sparql type should implement this type 
-/// it'll allow us to run a full query build and view the output, 
+/// types corresponding to a sparql type should implement this type
+/// it'll allow us to run a full query build and view the output,
 /// as if this were an AST pass
 ///
 pub trait QueryFragment {
     //TODO: we need error handling, this should be fallible
-    fn generate_fragment(&self, builder: &mut QueryBuilder); 
+    fn generate_fragment(&self, builder: &mut QueryBuilder);
 }
 
 ///
 /// A trait to mark "complete" queries, as opposed to fragmented types
-pub trait SparqlQuery {
-    fn generate_query(&self, builder: &mut QueryBuilder);
-}
-impl<T> QueryFragment for T where T: SparqlQuery {
+pub trait SparqlQuery {}
 
-    fn generate_fragment(&self, builder: &mut QueryBuilder) {
-        self.generate_query(builder);     
-    }
-}
-
-pub fn run_sparql_generation<T: SparqlQuery>(obj: T) -> String {
-    // I don't want to expose 
-    // a public interface to any function that allows 
+pub fn run_sparql_generation<T: SparqlQuery + QueryFragment>(obj: T) -> String {
+    // I don't want to expose
+    // a public interface to any function that allows
     // folks to generate a non-complete sparql query,
-    // however since TraitSparqlQuery is a subtype of QueryFragment, 
+    // however since TraitSparqlQuery is a subtype of QueryFragment,
     // we can just use this internally
-    test_gen_fragment(obj)
+    gen_fragment(obj)
 }
 
-pub(crate) fn test_gen_fragment<T: QueryFragment>(query_fragment: T) -> String {
+pub(crate) fn gen_fragment<T: QueryFragment>(query_fragment: T) -> String {
     let mut query_builder = QueryBuilder::new();
     query_fragment.generate_fragment(&mut query_builder);
     query_builder.get_result()
 }
-
 
 #[cfg(test)]
 mod fragment_tests {

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -6,6 +6,8 @@
 //! variable, that is usable in a triple or any other
 //! place where a valid variable or binding can be used
 
+use crate::query_build::QueryFragment;
+
 pub trait SPQLVar {}
 
 use crate::identifier::*;
@@ -19,3 +21,24 @@ pub struct Variable<T: Identifier> {
 
 impl<T> SPQLVar for Literal<T> where T: Identifier {}
 impl<T> SPQLVar for Variable<T> where T: Identifier {}
+
+use crate::query_build::QueryBuilder;
+
+impl<T> QueryFragment for Literal<T>
+where
+    T: Identifier,
+{
+    fn generate_fragment(&self, builder: &mut QueryBuilder) {
+        self.v.generate_fragment(builder);
+    }
+}
+
+impl<T> QueryFragment for Variable<T>
+where
+    T: Identifier,
+{
+    fn generate_fragment(&self, builder: &mut QueryBuilder) {
+        builder.write_element("?");
+        self.v.generate_fragment(builder);
+    }
+}

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -1,0 +1,25 @@
+//!
+//! WIP, ideal end state is to have
+//!
+//!
+//! A marker trait that indicates that a type is a valid
+//! variable, that is useable in a triple or any other
+//! place where a valid variable or binding can be used
+
+pub trait SPQLVar {}
+
+use crate::identifier::Ident;
+
+pub trait Identifier {
+    fn gen_identifier(&self) -> Ident;
+}
+
+pub struct Literal<T: Identifier> {
+   v: T, 
+}
+pub struct Variable<T: Identifier> {
+    v: T,
+}
+
+impl<T> SPQLVar for Literal<T> where T: Identifier {}
+impl<T> SPQLVar for Variable<T> where T: Identifier {}

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -8,11 +8,7 @@
 
 pub trait SPQLVar {}
 
-use crate::identifier::Ident;
-
-pub trait Identifier {
-    fn gen_identifier(&self) -> Ident;
-}
+use crate::identifier::*;
 
 pub struct Literal<T: Identifier> {
    v: T, 

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -3,7 +3,7 @@
 //!
 //!
 //! A marker trait that indicates that a type is a valid
-//! variable, that is useable in a triple or any other
+//! variable, that is usable in a triple or any other
 //! place where a valid variable or binding can be used
 
 pub trait SPQLVar {}

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -11,7 +11,7 @@ pub trait SPQLVar {}
 use crate::identifier::*;
 
 pub struct Literal<T: Identifier> {
-   v: T, 
+    v: T,
 }
 pub struct Variable<T: Identifier> {
     v: T,

--- a/sparql_orm/src/triple_pattern.rs
+++ b/sparql_orm/src/triple_pattern.rs
@@ -14,6 +14,11 @@ use std::marker::PhantomData;
 /// triple, or triple pattern
 pub trait SPQLTriple {}
 
+/// A marker for types that represent a triple with no variable bindings 
+pub trait SPQLConstTriple {}
+
+impl<T: SPQLConstTriple> SPQLTriple for T {}
+
 struct TriplePattern<Subject: SPQLVar, Predicate: SPQLVar, Object: SPQLVar> {
     subject  : PhantomData<Subject>,
     predicate : PhantomData<Predicate>,

--- a/sparql_orm/src/triple_pattern.rs
+++ b/sparql_orm/src/triple_pattern.rs
@@ -14,14 +14,14 @@ use std::marker::PhantomData;
 /// triple, or triple pattern
 pub trait SPQLTriple {}
 
-/// A marker for types that represent a triple with no variable bindings 
+/// A marker for types that represent a triple with no variable bindings
 pub trait SPQLConstTriple {}
 
 impl<T: SPQLConstTriple> SPQLTriple for T {}
 
 struct TriplePattern<Subject: SPQLVar, Predicate: SPQLVar, Object: SPQLVar> {
-    subject  : PhantomData<Subject>,
-    predicate : PhantomData<Predicate>,
+    subject: PhantomData<Subject>,
+    predicate: PhantomData<Predicate>,
     object: PhantomData<Object>,
 }
 

--- a/sparql_orm/src/triple_pattern.rs
+++ b/sparql_orm/src/triple_pattern.rs
@@ -1,0 +1,29 @@
+//!
+//! Provides top-level traits and markers
+//! for types implementing sparql triples
+//!
+//!
+//! Ideal end state: have a type like
+//! pub type Triple<Subject, Predicate, Object>, that we
+//! can then build like Triple<Var<Binding>, Literal<LiteralBinding>, Var<Object>
+
+use crate::sparql_var::SPQLVar;
+use std::marker::PhantomData;
+
+/// This is a marker trait to denote types that represent any valid
+/// triple, or triple pattern
+pub trait SPQLTriple {}
+
+struct TriplePattern<Subject: SPQLVar, Predicate: SPQLVar, Object: SPQLVar> {
+    subject  : PhantomData<Subject>,
+    predicate : PhantomData<Predicate>,
+    object: PhantomData<Object>,
+}
+
+impl<SU, PR, OBJ> SPQLTriple for TriplePattern<SU, PR, OBJ>
+where
+    SU: SPQLVar,
+    PR: SPQLVar,
+    OBJ: SPQLVar,
+{
+}


### PR DESCRIPTION
## Summary 
This adds `graph_specifier`, `identifier`, `insert_data`, `var`, `query_builder`, `triple_pattern` modules, which begin to scaffold  a highly type-safe interface for writing SPARQL Queries. 

## Context / Design 

The basic premise is to try to encode as much as we can about the Query logic into the type system. What this means is that for an update query that might look like this: 

```sparql

INSERT DATA graph Foo 
{
foaf:toast foaf:topping foaf:butter . 
}
```

This would be encapsulated by the following type: 
```rust 

pub type InsertDataClause
                   <GraphSelection, 
                   InsertTripleSet<TriplePattern<ConstLiteral, ConstLiteral, ConstLiteral>, NullTripleSet>
```

This type would encode the structure of an insert data statement. Aside from the literal text (i.e. Foo, toast, topping, and butter), everything else is part of the type. This prevents many classes of errors that would otherwise only be found by actually executing the generated query. 


## What's in this PR 

This PR sets a lot of the building blocks we need to start creating this sort of API: In order: 

### `graph_specifier` and `identifier` 

These are some of the absolute low level primitives needed. `graph_specifier` provides a marker trait for types that represent any way to identify a graph (see [this](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#insertData), for more details). 

Similarly, `identifier` does this for const & variable bindings. Any text (i.e. variable names, or actual literals), can be represented via an `identifier`. 

###  `sparql_var` and `triple_pattern`

`sparql_var` is a small wrapper around indentifier. It encodes information about whether an identifier is being used in a literal or variable binding context. 


`triple_pattern` encodes the basic idea of a SPARQL triple, (i.e. Subject, Predicate, and Object), as well as marker traits to encode any type that can represent such a pattern. It's main utility is in exporting this type 

```rust
struct TriplePattern<Subject: SPQLVar, Predicate: SPQLVar, Object: SPQLVar
```

### `insert_data_clause` 

A data type that represents an `INSERT DATA` statement, the SPARQL statement used literally to add data to a graph, and probably the simplest one we can encode. It exports the types shown in the above example at the top 


### `query_build` 

This is a draft module that is designed to implement an AST pass to actually produce executable SPARQL code, based on the type. It does this by providing a `QueryBuilder` object, and a `QueryFragment` trait that is implemented by all types that *can* be used to produce SPARQL output. Currently it is only implemented for `Identifier` and `sparql_var` types, but added `impls` will be added as we build up towards the full specification. 

