### PR TITLE
Sparql orm impl

### DIFF
--- a/sparql_orm/src/graph_specifier.rs
+++ b/sparql_orm/src/graph_specifier.rs
@@ -1,10 +1,42 @@
 //!
 //! Basic types for handling graph specifiers in sparql
 //!
+use crate::query_build::QueryFragment;
 
-pub type GraphIdent = String;
+#[derive(Clone, Debug)]
+pub struct GraphIdent(String);
 
 /// A trait that marks any type that can represent a graph specifier
 pub trait GraphSpecifier {
     fn gen_specifier(&self) -> GraphIdent;
+}
+
+impl GraphSpecifier for GraphIdent {
+    //TODO - Improve lifetime handling here 
+    fn gen_specifier(&self) -> GraphIdent {
+        self.clone()
+    }
+}
+
+use crate::query_build::QueryBuilder;
+impl QueryFragment for GraphIdent {
+    fn generate_fragment(&self, builder: &mut QueryBuilder) {
+        builder.write_element("GRAPH");
+        builder.write_element(" ");
+        builder.write_element(&self.gen_specifier().0);
+    }    
+}
+
+
+#[cfg(test)]
+mod graph_spec_tests {
+    use crate::query_build::gen_fragment;
+    use super::*;
+    #[test]
+    fn test_graph_specifier() {
+        let specifier = GraphIdent(String::from("test"));
+        let result = gen_fragment(specifier);
+        assert_eq!(result, "GRAPH test");
+    }
+
 }

--- a/sparql_orm/src/graph_specifier.rs
+++ b/sparql_orm/src/graph_specifier.rs
@@ -12,7 +12,7 @@ pub trait GraphSpecifier {
 }
 
 impl GraphSpecifier for GraphIdent {
-    //TODO - Improve lifetime handling here 
+    //TODO - Improve lifetime handling here
     fn gen_specifier(&self) -> GraphIdent {
         self.clone()
     }
@@ -24,19 +24,30 @@ impl QueryFragment for GraphIdent {
         builder.write_element("GRAPH");
         builder.write_element(" ");
         builder.write_element(&self.gen_specifier().0);
-    }    
+    }
 }
 
+///
+/// A type to mark essentially that we want to leave the graph unspecified and instead use the
+/// default graph
+pub struct DefaultGraphSpecifier;
+
+impl QueryFragment for DefaultGraphSpecifier {
+    fn generate_fragment(&self, builder: &mut QueryBuilder) {
+        // TODO: evaluate whether defaulting to using
+        // a default graph called "default" makes sense as a behavior?
+        builder.write_element("GRAPH default");
+    }
+}
 
 #[cfg(test)]
 mod graph_spec_tests {
-    use crate::query_build::gen_fragment;
     use super::*;
+    use crate::query_build::gen_fragment;
     #[test]
     fn test_graph_specifier() {
         let specifier = GraphIdent(String::from("test"));
         let result = gen_fragment(specifier);
         assert_eq!(result, "GRAPH test");
     }
-
 }

--- a/sparql_orm/src/identifier.rs
+++ b/sparql_orm/src/identifier.rs
@@ -18,8 +18,7 @@ impl Identifier for Ident {
 }
 use crate::query_build::QueryBuilder;
 
-impl QueryFragment for Ident
-{
+impl QueryFragment for Ident {
     fn generate_fragment(&self, builder: &mut QueryBuilder) {
         builder.write_element(&self.gen_identifier().0);
     }
@@ -27,8 +26,8 @@ impl QueryFragment for Ident
 
 #[cfg(test)]
 mod ident_tests {
+    use super::Ident;
     use crate::query_build::gen_fragment;
-    use super::Ident; 
     #[test]
     fn test_ident_generation() {
         let ident: Ident = Ident(String::from("test"));

--- a/sparql_orm/src/identifier.rs
+++ b/sparql_orm/src/identifier.rs
@@ -4,7 +4,8 @@
 //!
 use crate::query_build::{QueryFragment, SparqlQuery};
 
-pub type Ident = String;
+#[derive(Clone)]
+pub struct Ident(pub(crate) String);
 
 pub trait Identifier {
     fn gen_identifier(&self) -> Ident;
@@ -17,12 +18,10 @@ impl Identifier for Ident {
 }
 use crate::query_build::QueryBuilder;
 
-impl<T> QueryFragment for T
-where
-    T: Identifier,
+impl QueryFragment for Ident
 {
     fn generate_fragment(&self, builder: &mut QueryBuilder) {
-        builder.write_element(&self.gen_identifier());
+        builder.write_element(&self.gen_identifier().0);
     }
 }
 
@@ -32,7 +31,7 @@ mod ident_tests {
     use super::Ident; 
     #[test]
     fn test_ident_generation() {
-        let ident = String::from("test");
+        let ident: Ident = Ident(String::from("test"));
         let result = gen_fragment(ident);
         assert_eq!(result, "test");
     }

--- a/sparql_orm/src/query_build.rs
+++ b/sparql_orm/src/query_build.rs
@@ -39,11 +39,6 @@ pub trait QueryFragment {
 pub trait SparqlQuery {}
 
 pub fn run_sparql_generation<T: SparqlQuery + QueryFragment>(obj: T) -> String {
-    // I don't want to expose
-    // a public interface to any function that allows
-    // folks to generate a non-complete sparql query,
-    // however since TraitSparqlQuery is a subtype of QueryFragment,
-    // we can just use this internally
     gen_fragment(obj)
 }
 

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -43,24 +43,27 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod spql_var_tests {
-    use crate::sparql_var::{Literal, Variable};
-    use crate::query_build::gen_fragment;
     use crate::identifier::Ident;
-    
+    use crate::query_build::gen_fragment;
+    use crate::sparql_var::{Literal, Variable};
+
     #[test]
     fn test_literal_render() {
-        let lit = Literal { v : Ident(String::from("foo")) };
-        let result = gen_fragment(lit); 
+        let lit = Literal {
+            v: Ident(String::from("foo")),
+        };
+        let result = gen_fragment(lit);
         assert_eq!(result, "foo");
     }
 
     #[test]
     fn test_var_render() {
-        let lit = Variable { v : Ident(String::from("foo")) };
-        let result = gen_fragment(lit); 
+        let lit = Variable {
+            v: Ident(String::from("foo")),
+        };
+        let result = gen_fragment(lit);
         assert_eq!(result, "?foo");
     }
 }

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -26,7 +26,7 @@ use crate::query_build::QueryBuilder;
 
 impl<T> QueryFragment for Literal<T>
 where
-    T: Identifier,
+    T: Identifier + QueryFragment,
 {
     fn generate_fragment(&self, builder: &mut QueryBuilder) {
         self.v.generate_fragment(builder);
@@ -35,7 +35,7 @@ where
 
 impl<T> QueryFragment for Variable<T>
 where
-    T: Identifier,
+    T: Identifier + QueryFragment,
 {
     fn generate_fragment(&self, builder: &mut QueryBuilder) {
         builder.write_element("?");
@@ -48,18 +48,18 @@ where
 mod spql_var_tests {
     use crate::sparql_var::{Literal, Variable};
     use crate::query_build::gen_fragment;
-
+    use crate::identifier::Ident;
     
     #[test]
     fn test_literal_render() {
-        let lit = Literal { v : String::from("foo") };
+        let lit = Literal { v : Ident(String::from("foo")) };
         let result = gen_fragment(lit); 
         assert_eq!(result, "foo");
     }
 
     #[test]
     fn test_var_render() {
-        let lit = Variable { v : String::from("foo") };
+        let lit = Variable { v : Ident(String::from("foo")) };
         let result = gen_fragment(lit); 
         assert_eq!(result, "?foo");
     }

--- a/sparql_orm/src/triple_pattern.rs
+++ b/sparql_orm/src/triple_pattern.rs
@@ -53,9 +53,9 @@ where
 
 #[cfg(test)]
 mod triple_pattern_tests {
+    use crate::identifier::Ident;
     use crate::sparql_var::{Literal, Variable};
     use crate::{query_build::gen_fragment, triple_pattern::TriplePattern};
-    use crate::identifier::Ident;
     #[test]
     fn test_literal_triple() {
         let triple = TriplePattern {

--- a/sparql_orm/src/triple_pattern.rs
+++ b/sparql_orm/src/triple_pattern.rs
@@ -55,17 +55,18 @@ where
 mod triple_pattern_tests {
     use crate::sparql_var::{Literal, Variable};
     use crate::{query_build::gen_fragment, triple_pattern::TriplePattern};
+    use crate::identifier::Ident;
     #[test]
     fn test_literal_triple() {
         let triple = TriplePattern {
             subject: Literal {
-                v: String::from("foo"),
+                v: Ident(String::from("foo")),
             },
             predicate: Literal {
-                v: String::from("bar"),
+                v: Ident(String::from("bar")),
             },
             object: Literal {
-                v: String::from("baz"),
+                v: Ident(String::from("baz")),
             },
         };
         let result = gen_fragment(triple);
@@ -76,13 +77,13 @@ mod triple_pattern_tests {
     fn test_var_triple() {
         let triple = TriplePattern {
             subject: Literal {
-                v: String::from("foo"),
+                v: Ident(String::from("foo")),
             },
             predicate: Variable {
-                v: String::from("bar"),
+                v: Ident(String::from("bar")),
             },
             object: Variable {
-                v: String::from("baz"),
+                v: Ident(String::from("baz")),
             },
         };
 


### PR DESCRIPTION
## Summary 

Adding some testing, as well as the first semi - interesting implementation of `QueryFragment`, for Insert data. We should now be able to generate `INSERT DATA { graph Foo { toast topping butter; pancake topping syrup; }}` - esque queries, which should be evaulatable for a SPARQL database! 