### PR TITLE
Sparql orm impl

### DIFF
--- a/sparql_orm/src/identifier.rs
+++ b/sparql_orm/src/identifier.rs
@@ -2,7 +2,7 @@
 //! Basic types to represent a single SPARQL Identifier
 //! i.e. `name`, or `foaf:author`,
 //!
-use crate::query_build::{QueryFragment, SparqlQuery};
+use crate::query_build::QueryFragment;
 
 #[derive(Clone)]
 pub struct Ident(pub(crate) String);

--- a/sparql_orm/src/insert_data_clause.rs
+++ b/sparql_orm/src/insert_data_clause.rs
@@ -2,11 +2,10 @@
 //! A module containing insert clause related functionality, traits
 //! and types
 
-use crate::graph_specifier::{DefaultGraphSpecifier, GraphSpecifier};
+use crate::graph_specifier::GraphSpecifier;
 use crate::identifier::*;
 use crate::query_build::{QueryBuilder, QueryFragment, SparqlQuery};
 use crate::triple_pattern::SPQLConstTriple;
-use std::marker::PhantomData;
 
 /// A marker trait for types that can be evaluated as part of
 /// a InsertDataClause. Not that this explicitly will not
@@ -21,20 +20,18 @@ pub struct InsertTripleSet<CT: SPQLConstTriple, RST: InsertableDataTripleSet> {
     rst: RST,
 }
 
-impl<CT, RST> InsertableDataTripleSet for InsertTripleSet<CT, RST>
-where
+impl<CT, RST> InsertableDataTripleSet for InsertTripleSet<CT, RST> where
     CT: SPQLConstTriple,
-    RST: InsertableDataTripleSet,
-{
-}
+    RST: InsertableDataTripleSet
+{}
 
 impl InsertableDataTripleSet for EmptyTripleSet {}
 
-impl<CT, RST> QueryFragment for InsertTripleSet<CT, RST>
-where
-    CT: SPQLConstTriple + QueryFragment,
-    RST: InsertableDataTripleSet + QueryFragment,
+impl<CT, RST> QueryFragment for InsertTripleSet<CT, RST> where
+CT: SPQLConstTriple + QueryFragment,
+RST: InsertableDataTripleSet + QueryFragment,
 {
+    
     fn generate_fragment(&self, builder: &mut QueryBuilder) {
         self.ct.generate_fragment(builder);
         builder.write_element(";\n");
@@ -63,16 +60,29 @@ where
 {
 }
 
-impl<G, SEL> QueryFragment for InsertDataClause<G, SEL>
-where
-    G: GraphSpecifier + QueryFragment,
-    SEL: InsertableDataTripleSet + QueryFragment,
-{
+impl<G, SEL> QueryFragment for InsertDataClause<G, SEL> where
+G: GraphSpecifier + QueryFragment,
+SEL: InsertableDataTripleSet + QueryFragment {
     fn generate_fragment(&self, builder: &mut QueryBuilder) {
-        builder.write_element("INSERT DATA {");
+        builder.write_element("INSERT DATA {"); 
         self.graph_spec.generate_fragment(builder);
         builder.write_element("{");
         self.selector.generate_fragment(builder);
         builder.write_element("}}");
+    }
+
+}
+
+
+
+#[cfg(test)]
+mod insert_data_clause_tests {
+    use super::*;
+    use crate::query_build::gen_fragment;
+
+    
+    #[test]
+    fn test_basic_insert_data() {
+        
     }
 }

--- a/sparql_orm/src/insert_data_clause.rs
+++ b/sparql_orm/src/insert_data_clause.rs
@@ -20,18 +20,20 @@ pub struct InsertTripleSet<CT: SPQLConstTriple, RST: InsertableDataTripleSet> {
     rst: RST,
 }
 
-impl<CT, RST> InsertableDataTripleSet for InsertTripleSet<CT, RST> where
+impl<CT, RST> InsertableDataTripleSet for InsertTripleSet<CT, RST>
+where
     CT: SPQLConstTriple,
-    RST: InsertableDataTripleSet
-{}
+    RST: InsertableDataTripleSet,
+{
+}
 
 impl InsertableDataTripleSet for EmptyTripleSet {}
 
-impl<CT, RST> QueryFragment for InsertTripleSet<CT, RST> where
-CT: SPQLConstTriple + QueryFragment,
-RST: InsertableDataTripleSet + QueryFragment,
+impl<CT, RST> QueryFragment for InsertTripleSet<CT, RST>
+where
+    CT: SPQLConstTriple + QueryFragment,
+    RST: InsertableDataTripleSet + QueryFragment,
 {
-    
     fn generate_fragment(&self, builder: &mut QueryBuilder) {
         self.ct.generate_fragment(builder);
         builder.write_element(";\n");
@@ -60,29 +62,25 @@ where
 {
 }
 
-impl<G, SEL> QueryFragment for InsertDataClause<G, SEL> where
-G: GraphSpecifier + QueryFragment,
-SEL: InsertableDataTripleSet + QueryFragment {
+impl<G, SEL> QueryFragment for InsertDataClause<G, SEL>
+where
+    G: GraphSpecifier + QueryFragment,
+    SEL: InsertableDataTripleSet + QueryFragment,
+{
     fn generate_fragment(&self, builder: &mut QueryBuilder) {
-        builder.write_element("INSERT DATA {"); 
+        builder.write_element("INSERT DATA {");
         self.graph_spec.generate_fragment(builder);
         builder.write_element("{");
         self.selector.generate_fragment(builder);
         builder.write_element("}}");
     }
-
 }
-
-
 
 #[cfg(test)]
 mod insert_data_clause_tests {
     use super::*;
     use crate::query_build::gen_fragment;
 
-    
     #[test]
-    fn test_basic_insert_data() {
-        
-    }
+    fn test_basic_insert_data() {}
 }

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -1,7 +1,4 @@
 //!
-//! WIP, ideal end state is to have
-//!
-//!
 //! A marker trait that indicates that a type is a valid
 //! variable, that is usable in a triple or any other
 //! place where a valid variable or binding can be used
@@ -23,7 +20,7 @@ pub struct Variable<T: Identifier> {
 impl<T> SPQLVar for Literal<T> where T: Identifier {}
 impl<T> SPQLVar for Variable<T> where T: Identifier {}
 
-/// Implemented only for types representing non-variable bindings 
+/// Implemented only for types representing non-variable bindings
 impl<T> ConstVar for Literal<T> where T: Identifier {}
 
 use crate::query_build::QueryBuilder;
@@ -45,6 +42,25 @@ where
         builder.write_element("?");
         self.v.generate_fragment(builder);
     }
+}
+
+
+/*
+ * Util Methods 
+ */
+use std::string::ToString;
+
+impl Literal<Ident> {
+    pub fn new(name: impl ToString) -> Self {
+        Self { v : Ident(name.to_string()) }
+    }
+}
+
+impl Variable<Ident> {
+    pub fn new(name: impl ToString) -> Self {
+        Self { v : Ident(name.to_string()) }
+    }
+
 }
 
 #[cfg(test)]

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -9,6 +9,7 @@
 use crate::query_build::QueryFragment;
 
 pub trait SPQLVar {}
+pub trait ConstVar {}
 
 use crate::identifier::*;
 
@@ -21,6 +22,9 @@ pub struct Variable<T: Identifier> {
 
 impl<T> SPQLVar for Literal<T> where T: Identifier {}
 impl<T> SPQLVar for Variable<T> where T: Identifier {}
+
+/// Implemented only for types representing non-variable bindings 
+impl<T> ConstVar for Literal<T> where T: Identifier {}
 
 use crate::query_build::QueryBuilder;
 

--- a/sparql_orm/src/sparql_var.rs
+++ b/sparql_orm/src/sparql_var.rs
@@ -44,23 +44,25 @@ where
     }
 }
 
-
 /*
- * Util Methods 
+ * Util Methods
  */
 use std::string::ToString;
 
 impl Literal<Ident> {
     pub fn new(name: impl ToString) -> Self {
-        Self { v : Ident(name.to_string()) }
+        Self {
+            v: Ident(name.to_string()),
+        }
     }
 }
 
 impl Variable<Ident> {
     pub fn new(name: impl ToString) -> Self {
-        Self { v : Ident(name.to_string()) }
+        Self {
+            v: Ident(name.to_string()),
+        }
     }
-
 }
 
 #[cfg(test)]

--- a/sparql_orm/src/triple_pattern.rs
+++ b/sparql_orm/src/triple_pattern.rs
@@ -70,9 +70,9 @@ type ConstTriple = TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>>
 impl TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>> {
     pub fn new(sub: impl ToString, pred: impl ToString, obj: impl ToString) -> Self {
         Self {
-        subject: Literal::<Ident>::new(sub),
-        predicate: Literal::<Ident>::new(pred), 
-        object: Literal::<Ident>::new(obj), 
+            subject: Literal::<Ident>::new(sub),
+            predicate: Literal::<Ident>::new(pred),
+            object: Literal::<Ident>::new(obj),
         }
     }
 }
@@ -83,7 +83,7 @@ mod triple_pattern_tests {
     use crate::sparql_var::{Literal, Variable};
     use crate::{
         query_build::gen_fragment,
-        triple_pattern::{SPQLConstTriple,ConstTriple, TriplePattern},
+        triple_pattern::{ConstTriple, SPQLConstTriple, TriplePattern},
     };
     #[test]
     fn test_literal_triple() {

--- a/sparql_orm/src/triple_pattern.rs
+++ b/sparql_orm/src/triple_pattern.rs
@@ -7,7 +7,7 @@
 //! pub type Triple<Subject, Predicate, Object>, that we
 //! can then build like Triple<Var<Binding>, Literal<LiteralBinding>, Var<Object>
 
-use crate::query_build::QueryFragment;
+use crate::query_build::{QueryBuilder, QueryFragment};
 use crate::sparql_var::{ConstVar, SPQLVar};
 
 /// This is a marker trait to denote types that represent any valid
@@ -17,11 +17,16 @@ pub trait SPQLTriple {}
 /// A marker for types that represent a triple with no variable bindings
 pub trait SPQLConstTriple {}
 
-
 ///
 /// This implements 'ConstTriple' for all Triples that only contain
 /// Constants / Literals in them
-impl<SU, PR, OBJ> SPQLConstTriple for TriplePattern<SU, PR, OBJ> where SU: ConstVar + SPQLVar, PR: ConstVar + SPQLVar, OBJ: ConstVar + SPQLVar {}
+impl<SU, PR, OBJ> SPQLConstTriple for TriplePattern<SU, PR, OBJ>
+where
+    SU: ConstVar + SPQLVar,
+    PR: ConstVar + SPQLVar,
+    OBJ: ConstVar + SPQLVar,
+{
+}
 
 struct TriplePattern<Subject: SPQLVar, Predicate: SPQLVar, Object: SPQLVar> {
     subject: Subject,
@@ -36,8 +41,6 @@ where
     OBJ: SPQLVar,
 {
 }
-
-use crate::query_build::QueryBuilder;
 
 impl<SU, PR, OBJ> QueryFragment for TriplePattern<SU, PR, OBJ>
 where
@@ -54,24 +57,37 @@ where
     }
 }
 
+/*
+ * Util Methods
+ */
+
+use crate::identifier::Ident;
+use crate::sparql_var::Literal;
+use std::string::ToString;
+
+type ConstTriple = TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>>;
+
+impl TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>> {
+    pub fn new(sub: impl ToString, pred: impl ToString, obj: impl ToString) -> Self {
+        Self {
+        subject: Literal::<Ident>::new(sub),
+        predicate: Literal::<Ident>::new(pred), 
+        object: Literal::<Ident>::new(obj), 
+        }
+    }
+}
+
 #[cfg(test)]
 mod triple_pattern_tests {
-    use crate::sparql_var::{Literal, Variable};
-    use crate::{query_build::gen_fragment, triple_pattern::{SPQLConstTriple, TriplePattern}};
     use crate::identifier::Ident;
+    use crate::sparql_var::{Literal, Variable};
+    use crate::{
+        query_build::gen_fragment,
+        triple_pattern::{SPQLConstTriple,ConstTriple, TriplePattern},
+    };
     #[test]
     fn test_literal_triple() {
-        let triple = TriplePattern {
-            subject: Literal {
-                v: Ident(String::from("foo")),
-            },
-            predicate: Literal {
-                v: Ident(String::from("bar")),
-            },
-            object: Literal {
-                v: Ident(String::from("baz")),
-            },
-        };
+        let triple = ConstTriple::new("foo", "bar", "baz");
         let result = gen_fragment(triple);
         assert_eq!(result, "foo bar baz");
     }
@@ -94,11 +110,14 @@ mod triple_pattern_tests {
         assert_eq!(result, "foo ?bar ?baz");
     }
 
-    fn test_const_trip<T>() where T: SPQLConstTriple {}
+    fn test_const_trip<T>()
+    where
+        T: SPQLConstTriple,
+    {
+    }
 
     #[test]
     fn assert_const_triple_impl() {
-        test_const_trip::<TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>>>(); 
-
+        test_const_trip::<TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>>>();
     }
 }


### PR DESCRIPTION
## Summary 

Adds a number of utilities / helper functions, as well as more tests to make this easier to work with, now supports things like: 

```rust
let x = ConstTriple::new("foo", "bar", "baz");
```

which desugars into a 

```rust
let x: <TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>> = /*....*/
```

This should make it easier to write tests, and to actually write application logic on top of this type system