### PR TITLE
Sparql orm impl

### DIFF
--- a/'
+++ b/'
@@ -1,0 +1,23 @@
+//!
+//! WIP, ideal end state is to have 
+//!
+//!
+//! A marker trait that indicates that a type is a valid 
+//! variable, that is useable in a triple or any other 
+//! place where a valid variable or binding can be used 
+pub trait SPQLVar {}
+
+pub trait Identifier {
+    fn gen_identifier(&self) -> Ident;
+}
+
+pub struct Literal<T: Identifier>;
+pub struct Variable<T: Identifier>;
+
+
+//!
+//! Blanket trait impls
+//!
+impl<T> SPQLVar for Literal<T> where T: Identifier {}
+impl<T> SPQLVar for Variable<T> where T: Identifier {}
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "sparql_orm"
+version = "0.1.0"
+
+[[package]]
 name = "sparql_server_client"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@
 members = [
     "sparql_server_client",
     "tree_sitter_parser",
+    "sparql_orm",
 ]

--- a/sparql_orm/src/graph_specifier.rs
+++ b/sparql_orm/src/graph_specifier.rs
@@ -40,6 +40,13 @@ impl QueryFragment for DefaultGraphSpecifier {
     }
 }
 
+use std::string::ToString;
+impl GraphIdent {
+    pub fn new(s: impl ToString) -> Self {
+        Self(s.to_string())
+    }
+}
+
 #[cfg(test)]
 mod graph_spec_tests {
     use super::*;

--- a/sparql_orm/src/triple_pattern.rs
+++ b/sparql_orm/src/triple_pattern.rs
@@ -28,7 +28,7 @@ where
 {
 }
 
-struct TriplePattern<Subject: SPQLVar, Predicate: SPQLVar, Object: SPQLVar> {
+pub struct TriplePattern<Subject: SPQLVar, Predicate: SPQLVar, Object: SPQLVar> {
     subject: Subject,
     predicate: Predicate,
     object: Object,
@@ -65,7 +65,7 @@ use crate::identifier::Ident;
 use crate::sparql_var::Literal;
 use std::string::ToString;
 
-type ConstTriple = TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>>;
+pub type ConstTriple = TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>>;
 
 impl TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>> {
     pub fn new(sub: impl ToString, pred: impl ToString, obj: impl ToString) -> Self {
@@ -119,5 +119,10 @@ mod triple_pattern_tests {
     #[test]
     fn assert_const_triple_impl() {
         test_const_trip::<TriplePattern<Literal<Ident>, Literal<Ident>, Literal<Ident>>>();
+    }
+
+    #[test]
+    fn assert_type_alias_impl() {
+        test_const_trip::<ConstTriple>();
     }
 }


### PR DESCRIPTION
## Summary 

This change does two things - it actually implements generation & adds tests for the `InsertDataClause`(exciting!). It also refactors the `InsertTripleSet` to be based on `const generics` rather than a recursive collection type.