### PR TITLE
Sparql orm impl

### DIFF
--- a/sparql_orm/src/delete_data_clause.rs
+++ b/sparql_orm/src/delete_data_clause.rs
@@ -1,0 +1,34 @@
+use crate::graph_specifier::{GraphIdent, GraphSpecifier};
+use crate::query_build::{QueryBuilder, QueryFragment};
+use crate::triple_pattern::{ConstTriple, SPQLConstTriple};
+
+/// A marker trait for collections which
+/// can be evaluate as part of a Delete Data statement
+pub trait DeletableTripleSet {}
+
+impl<CT, const N: usize> DeletableTripleSet for [CT; N] where CT: SPQLConstTriple {}
+
+///
+/// The main structure that holds
+/// all of the elements to be deleted
+///
+pub struct DeleteDataClause<G: GraphSpecifier, CT: DeletableTripleSet> {
+    graph: G,
+    elems: CT,
+}
+
+impl<G, CT> QueryFragment for DeleteDataClause<G, CT>
+where
+    CT: QueryFragment + DeletableTripleSet,
+    G: GraphSpecifier + QueryFragment,
+{
+    fn generate_fragment(&self, builder: &mut QueryBuilder) {
+        builder.write_element("DELETE DATA { ");
+        self.graph.generate_fragment(builder);
+        builder.write_element("{ ");
+        self.elems.generate_fragment(builder);
+        builder.write_element("}}");
+    }
+}
+
+type DeleteDataStatement<const N: usize> = DeleteDataClause<GraphIdent, [ConstTriple; N]>;

--- a/sparql_orm/src/lib.rs
+++ b/sparql_orm/src/lib.rs
@@ -3,6 +3,7 @@
 //! sparql based queries. It implements a subset
 //! of the w3c specification for both query and update calls
 
+pub mod delete_data_clause;
 pub mod graph_specifier;
 pub mod identifier;
 pub mod insert_data_clause;


### PR DESCRIPTION
## Summary 

Implements an equivalent `DELETE DATA` statement, so we can start generating delete data clauses as well. This also removes the `InsertDataTriple` intermediary type, since we can instead use `[T; N]` directly. The upside here is that there are fewer types overall, and in general the collection used to contain all of the different data points we want to insert / delete should be an implementation detail, as long as they implement both `Insertable/DeletableTripleSet`. 